### PR TITLE
template: fix: reflect page.title in <title>

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,6 +1,6 @@
 +++
 paginate_by = 10
 sort_by = "date"
+title = "Events, past and future"
 +++
 
-OtaNix events, past and future.

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,17 @@
         <meta http-equiv="content-type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover">
         {% if config.title %}
-        <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+        <title>
+            {% block title %}
+                {% if page.title %}
+                {{ config.title }}: {{ page.title }}
+                {% elif section.title %}
+                {{ config.title }}: {{ section.title }}
+                {% else %}
+                {{ config.title }}
+                {% endif %}
+            {% endblock title %}
+        </title>
         {% endif %}
         {% if page.description %}
         <meta name="description" content="{{ page.description }}">


### PR DESCRIPTION
Should fix URL previews in Discourse, Signal, etc.